### PR TITLE
Add web deployment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Virus Simulator
+
+This repo contains a simple Pygame-based virus simulator. To run locally, install the dependencies and execute `main.py`:
+
+```bash
+pip install -r requirements.txt
+python main.py
+```
+
+## Building a Web Version
+
+This project can also be compiled for the browser using [pygbag](https://github.com/pygame-web/pygbag). After installing the dependencies, run:
+
+```bash
+pygbag --build main.py
+```
+
+The command creates a `build/web` directory containing a standalone web version. Host the contents of that directory using any static file server (for example, `python -m http.server`). Open the generated `index.html` to run the simulator in a web browser.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pygame
+pygbag


### PR DESCRIPTION
## Summary
- add `.gitignore`
- document running the simulator and building a web version with pygbag
- specify dependencies in `requirements.txt`

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68600348be5483328fa9f32a253a78a9